### PR TITLE
[feat] Add inference.py & [refactor] torch baseline

### DIFF
--- a/torch/inference.py
+++ b/torch/inference.py
@@ -1,0 +1,80 @@
+import argparse
+
+import pandas as pd
+import albumentations as albu
+
+from tqdm import tqdm
+from torch.utils.data import DataLoader
+
+from dataset import CustomDataLoader, collate_fn
+from smp_model import build_model
+from utils import *
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--split', type=str, default="test")
+    parser.add_argument('--seed', type=int, default=42)
+
+    parser.add_argument('--data-dir', type=str, default='/opt/ml/input/data')
+    parser.add_argument('--work-dir', type=str, default='./work_dirs')
+    parser.add_argument('--config-dir', type=str, default='./config.yaml')
+
+    parser.add_argument('--exp-name', type=str, default='exp_7')
+    parser.add_argument('--model-name', type=str, default='best_miou')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = get_parser()
+    args = load_config(args)
+    set_seed(args.seed)
+    
+    device = args.device
+    
+    model, preprocessing_fn = build_model(args)
+    test_dataset = CustomDataLoader(data_dir=os.path.join(args.data_dir, 'test.json'), mode='test',
+                                    preprocessing=preprocessing_fn)
+    test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size, num_workers=args.num_worker,
+                                 pin_memory=True, collate_fn=collate_fn)
+    model_dir = os.path.join(args.work_dir_exp, f"{args.model_name}.pth")
+    model.load_state_dict(torch.load(model_dir))
+    model.to(device)
+
+    model.eval()
+    size = 256
+    transform = albu.Compose([albu.Resize(size, size)])
+    file_name_list = []
+    preds_array = np.empty((0, size * size), dtype=np.long)
+
+    pbar = tqdm(test_dataloader, total=len(test_dataloader), desc=f"Test")
+    with torch.no_grad():
+        for i, (images, image_infos) in enumerate(pbar):
+            output = model(torch.stack(images).float().to(device))
+            oms = torch.argmax(output.squeeze(), dim=1).detach().cpu().numpy()
+
+            temp_mask = []
+            images = torch.stack(images).float().detach().cpu().numpy()
+            for img, mask in zip(images, oms):
+                transformed = transform(image=img, mask=mask)
+                mask = transformed['mask']
+                temp_mask.append(mask)
+            oms = np.array(temp_mask)
+
+            oms = oms.reshape([oms.shape[0], size * size]).astype(int)
+            preds_array = np.vstack((preds_array, oms))
+
+            file_name_list.append([i['file_name'] for i in image_infos])
+        
+        file_names = [y for x in file_name_list for y in x]
+
+    submission = pd.read_csv('../submission/sample_submission.csv', index_col=None)
+    for file_name, string in zip(file_names, preds_array):
+        submission = submission.append(
+            {"image_id": file_name, "PredictionString": ' '.join(str(e) for e in string.tolist())},
+            ignore_index=True)
+    submission.to_csv(os.path.join(args.work_dir_exp, f"{args.model_name}.csv"), index=False)
+
+if __name__ == "__main__":
+    main()

--- a/torch/smp_model.py
+++ b/torch/smp_model.py
@@ -13,6 +13,5 @@ def build_model(args):
         decoder_channels=[256, 128, 64, 32, 16]
     )
     preprocessing_fn = smp.encoders.get_preprocessing_fn(args.encoder, args.encoder_weights)
-    model.to(args.device)
+    
     return model, preprocessing_fn
-

--- a/torch/train.py
+++ b/torch/train.py
@@ -1,22 +1,21 @@
-import os
-import os.path as osp
 import argparse
 import warnings
 
 import wandb
-from torch.optim import *
+
 from tqdm import tqdm
+from torch.optim import *
 
 from dataset import load_dataset
 from loss import get_loss
 from smp_model import build_model
 from utils import *
-from wandb_setup import *
+from wandb_setup import wandb_login, wandb_init
 
 warnings.filterwarnings('ignore')
 
 class_labels = {
-    0: "Backgroud",
+    0: "Background",
     1: "General trash",
     2: "Paper",
     3: "Paper pack",
@@ -32,16 +31,15 @@ class_labels = {
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data-dir', default='/opt/ml/input/data')
-    parser.add_argument('--config-dir', type=str, default='./config.yaml')
-    parser.add_argument('--name', type=str, default="test")
+    parser.add_argument('--split', type=str, default="train")
     parser.add_argument('--seed', type=int, default=42)
+
+    parser.add_argument('--data-dir', default='/opt/ml/input/data')
+    parser.add_argument('--work_dir', type=str, default='./work_dirs')
+    parser.add_argument('--config-dir', type=str, default='./config.yaml')
+    
     parser.add_argument('--viz-log', type=int, default=20)
-    parser.add_argument('--metric', action='store_true')
-    parser.add_argument('--loss', action='store_true')
     parser.add_argument('--save-interval', default=5)
-    parser.add_argument('--work_dir', type=str, default='./work_dirs',
-                        help='the root dir to save logs and models about each experiment')
     arg = parser.parse_args()
     return arg
 
@@ -53,13 +51,12 @@ def main():
 
     model, preprocessing_fn = build_model(args)
     train_loader, val_loader = load_dataset(args, preprocessing_fn)
-
-    # Loss
+    model.to(args.device)
+    
     criterion = get_loss(args.criterion)
     optimizer = Adam(model.parameters(), lr=args.lr)
     scheduler = lr_scheduler.MultiStepLR(optimizer, milestones=[30, 45], gamma=0.1)
 
-    # Wandb init
     wandb_login()
     wandb_init(args)
     wandb.config = {
@@ -78,10 +75,11 @@ def main():
         model.train()
         train_loss, train_miou_score, train_accuracy = 0, 0, 0
         train_f1_score, train_recall, train_precision = 0, 0, 0
+        hist = np.zeros((args.classes, args.classes))
         pbar = tqdm(train_loader, total=len(train_loader), desc=f"[Epoch {epoch}] Train")
-        for i, data in enumerate(pbar):
+        for idx, data in enumerate(pbar):
             image, mask = data
-            image, mask = image.to(device), mask.to(device)
+            image, mask = image.float().to(device), mask.long().to(device)
             output = model(image)
 
             optimizer.zero_grad()
@@ -90,24 +88,29 @@ def main():
             optimizer.step()
 
             train_loss += loss.item()
-            train_miou_score += mIoU(output, mask)
-            train_accuracy += pixel_accuracy(output, mask)
+
+            hist = add_hist(hist, mask, output, n_class=args.classes)
+            acc, acc_cls, mIoU, fwavacc, IoU = label_accuracy_score(hist)
+            train_miou_score += mIoU
+            train_accuracy += acc
+
             f1_score, recall, precision = get_metrics(output, mask)
             train_f1_score += f1_score.item()
             train_recall += recall.item()
             train_precision += precision.item()
             pbar.set_postfix(
-                Train_Loss=f" {train_loss/(i+1):.3f}",
-                Train_Iou=f" {train_miou_score/(i+1):.3f}",
-                Train_Acc=f" {train_accuracy/(i+1):.3f}",
+                Train_Loss=f" {train_loss / (idx+1):.3f}",
+                Train_Iou=f" {train_miou_score / (idx+1):.3f}",
+                Train_Acc=f" {train_accuracy / (idx+1):.3f}",
             )
+            
         wandb.log({
-            'train/loss': train_loss/len(train_loader),
-            'train/miou_score': train_miou_score/len(train_loader),
-            'train/pixel_accuracy': train_accuracy/len(train_loader),
-            'train/f1_score': train_f1_score/len(train_loader),
-            'train/recall': train_recall/len(train_loader),
-            'train/precision': train_precision/len(train_loader),
+            'train/loss': train_loss / len(train_loader),
+            'train/miou_score': train_miou_score / len(train_loader),
+            'train/accuracy': train_accuracy / len(train_loader),
+            'train/f1_score': train_f1_score / len(train_loader),
+            'train/recall': train_recall / len(train_loader),
+            'train/precision': train_precision / len(train_loader),
             'learning_rate': scheduler.get_lr()[0],
         }, commit=False)
 
@@ -115,32 +118,35 @@ def main():
         scheduler.step()
         val_loss, val_miou_score, val_accuracy = 0, 0, 0
         val_f1_score, val_recall, val_precision = 0, 0, 0
-        val_iou_by_cls = [0] * 11
         val_pbar = tqdm(val_loader, total=len(val_loader), desc=f"[Epoch {epoch}] Valid")
         with torch.no_grad():
             model.eval()
-            for i, data in enumerate(val_pbar):
+            hist = np.zeros((args.classes, args.classes))
+            for idx, data in enumerate(val_pbar):
                 image, mask = data
-                image, mask = image.to(device), mask.to(device)
+                image, mask = image.float().to(device), mask.long().to(device)
                 output = model(image)
 
                 loss = criterion(output, mask)
                 val_loss += loss.item()
-                val_miou_score += mIoU(output, mask)
-                val_iou_by_cls = [x+y for x,y in zip(val_iou_by_cls, mIoU(output, mask, classwise=True))]
-                val_accuracy += pixel_accuracy(output, mask)
+                
+                hist = add_hist(hist, mask, output, n_class=args.classes)
+                acc, acc_cls, mIoU, fwavacc, IoU = label_accuracy_score(hist)
+                val_miou_score += mIoU
+                val_accuracy += acc
+                
                 f1_score, recall, precision = get_metrics(output, mask)
                 val_f1_score += f1_score.item()
                 val_recall += recall.item()
                 val_precision += precision.item()
-
                 val_pbar.set_postfix(
-                    Valid_Loss=f" {val_loss / (i + 1):.3f}",
-                    Valid_Iou=f" {val_miou_score / (i + 1):.3f}",
-                    Valid_Acc=f" {val_accuracy / (i + 1):.3f}",
+                    Valid_Loss=f" {val_loss / (idx+1):.3f}",
+                    Valid_Iou=f" {val_miou_score / (idx+1):.3f}",
+                    Valid_Acc=f" {val_accuracy / (idx+1):.3f}",
                 )
+
                 output = torch.argmax(output, dim=1).detach().cpu().numpy()
-                if args.viz_log == i:
+                if args.viz_log == idx:
                     wandb.log({
                         'visualize': wandb.Image(
                             image[0, :, :, :],
@@ -156,37 +162,40 @@ def main():
                             }
                         )
                     }, commit=False)
+            
+            IoU_by_class = [
+                {class_name:round(IoU,4)} for IoU,class_name in zip( IoU, list(class_labels.values()) )
+            ]
+            
             wandb.log({
-                'val/loss': val_loss/len(val_loader),
-                'val/miou_score': val_miou_score/len(val_loader),
-                'val/pixel_accuracy': val_accuracy/len(val_loader),
-                'val/f1_score': val_f1_score/len(val_loader),
-                'val/recall': val_recall/len(val_loader),
-                'val/precision': val_precision/len(val_loader),
-                'cls/0 Background': val_iou_by_cls[0]/len(val_loader),
-                'cls/1 General trash': val_iou_by_cls[1]/len(val_loader),
-                'cls/2 Paper': val_iou_by_cls[2]/len(val_loader),
-                'cls/3 Paper pack': val_iou_by_cls[3]/len(val_loader),
-                'cls/4 Metal': val_iou_by_cls[4]/len(val_loader),
-                'cls/5 Glass': val_iou_by_cls[5]/len(val_loader),
-                'cls/6 Plastic': val_iou_by_cls[6]/len(val_loader),
-                'cls/7 Styrofoam': val_iou_by_cls[7]/len(val_loader),
-                'cls/8 Plastic bag': val_iou_by_cls[8]/len(val_loader),
-                'cls/9 Battery': val_iou_by_cls[9]/len(val_loader),
-                'cls/10 Clothing': val_iou_by_cls[10]/len(val_loader),
+                'val/loss': val_loss / len(val_loader),
+                'val/miou_score': val_miou_score / len(val_loader),
+                'val/accuracy': val_accuracy / len(val_loader),
+                'val/f1_score': val_f1_score / len(val_loader),
+                'val/recall': val_recall / len(val_loader),
+                'val/precision': val_precision / len(val_loader),
+                'cls/0 Background': IoU_by_class[0]['Background'],
+                'cls/1 General trash': IoU_by_class[1]['General trash'],
+                'cls/2 Paper': IoU_by_class[2]['Paper'],
+                'cls/3 Paper pack': IoU_by_class[3]['Paper pack'],
+                'cls/4 Metal': IoU_by_class[4]['Metal'],
+                'cls/5 Glass': IoU_by_class[5]['Glass'],
+                'cls/6 Plastic': IoU_by_class[6]['Plastic'],
+                'cls/7 Styrofoam': IoU_by_class[7]['Styrofoam'],
+                'cls/8 Plastic bag': IoU_by_class[8]['Plastic bag'],
+                'cls/9 Battery': IoU_by_class[9]['Battery'],
+                'cls/10 Clothing': IoU_by_class[10]['Clothing'],
             })
             
         # save_model
-        if args.metric:
-            if best_score < val_miou_score:
-                best_score = val_miou_score
-                ckpt_path = os.path.join(args.work_dir_exp, 'best_miou.pth')
-                torch.save(model.state_dict(), ckpt_path)
-        if not args.metric:
-            if best_loss > val_loss:
-                best_loss = val_loss
-                ckpt_path = os.path.join(args.work_dir_exp, 'best_loss.pth')
-                torch.save(model.state_dict(), ckpt_path)
+        if best_score < val_miou_score:
+            best_score = val_miou_score
+            ckpt_path = os.path.join(args.work_dir_exp, 'best_miou.pth')
+            torch.save(model.state_dict(), ckpt_path)
+        if best_loss > val_loss:
+            best_loss = val_loss
+            ckpt_path = os.path.join(args.work_dir_exp, 'best_loss.pth')
+            torch.save(model.state_dict(), ckpt_path)
         if (epoch + 1) % args.save_interval == 0:
             ckpt_fpath = os.path.join(args.work_dir_exp, 'latest.pth')
             torch.save(model.state_dict(), ckpt_fpath)

--- a/torch/utils.py
+++ b/torch/utils.py
@@ -1,77 +1,66 @@
 import os
 import random
-from statistics import mean
-
+import yaml
 import numpy as np
-import segmentation_models_pytorch as smp
+
 import torch
 import torch.nn.functional as F
-import yaml
+
+import segmentation_models_pytorch as smp
+
 from munch import Munch
-import glob
-from pathlib import Path
-import re
 
-
-def increment_path(path, exist_ok=False):
-    """ Automatically increment path, i.e. runs/exp --> runs/exp0, runs/exp1 etc.
-    Args:
-        path (str or pathlib.Path): f"{model_dir}/{args.name}".
-        exist_ok (bool): whether increment path (increment if False).
-    """
-    path = Path(path)
-    if (path.exists() and exist_ok) or (not path.exists()):
-        return str(path)
-    else:
-        dirs = glob.glob(f"{path}*")
-        print(f'dirs: {dirs}')
-        matches = [
-            re.search(rf"%s(\d+)" % path.stem, d) for d in dirs
-        ]
-        print(f'matches: {matches}')
-        i = [int(m.groups()[0]) for m in matches if m]
-        n = max(i) + 1 if i else 2
-        workdir = f"{path}{n}"
-        return workdir
 
 def set_seed(seed):
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    np.random.default_rng(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)  # if use multi-GPU
-    os.environ['PYTHONHASHSEED'] = str(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-    np.random.seed(seed)
-    random.seed(seed)
+
+
+def get_exp_dir(work_dir):
+    work_dir = work_dir.split('./')[-1]
+    if not os.path.exists(os.path.join(os.getcwd(), work_dir)):
+        exp_dir = os.path.join(os.getcwd(), work_dir, 'exp_0')
+    else:
+        idx = 1
+        exp_dir = os.path.join(os.getcwd(), work_dir, f'exp_{idx}')
+        while os.path.exists(exp_dir):
+            idx += 1
+            exp_dir = os.path.join(os.getcwd(), work_dir, f'exp_{idx}')
+    
+    os.makedirs(exp_dir)
+    return exp_dir
 
 
 def concat_config(arg, config):
     config = Munch(config)
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    
+    config['split'] = arg.split
     config['seed'] = arg.seed
-    config['name'] = arg.name
-    config['work_dir'] = arg.work_dir
-    if not os.path.exists(os.path.join(os.getcwd(), arg.work_dir)):
-        dir_name = os.path.join(os.getcwd(), arg.work_dir, f'exp_0')
-        os.makedirs(dir_name)
-    else:
-        i = 1
-        dir_name = os.path.join(os.getcwd(), arg.work_dir, f'exp_{i}')
-        while os.path.exists(dir_name):
-            i += 1
-            dir_name = os.path.join(os.getcwd(), arg.work_dir, f'exp_{i}')
-        os.makedirs(dir_name)
-    config['work_dir_exp'] = dir_name
-    with open(os.path.join(dir_name, 'config.yaml'), 'w') as f:
-        yaml.safe_dump(config, f)
-    config['save_dir'] = dir_name
-    config['device'] = device
+    config['device'] = 'cuda' if torch.cuda.is_available() else 'cpu'
     config['data_dir'] = arg.data_dir
-    config['viz_log'] = arg.viz_log
-    config['metric'] = arg.metric
-    config['loss'] = arg.loss
-    config['save_interval'] = arg.save_interval
+    config['work_dir'] = arg.work_dir
+    config['config_dir'] = arg.config_dir
 
+    if config['split'] == 'train':
+        exp_dir = get_exp_dir(arg.work_dir)
+        with open(os.path.join(exp_dir, 'config.yaml'), 'w') as f:
+            yaml.safe_dump(config, f)
+        config['work_dir_exp'] = exp_dir
+        config['viz_log'] = arg.viz_log
+        config['save_interval'] = arg.save_interval
+
+    else:
+        config['exp_name'] = arg.exp_name
+        config['model_name'] = arg.model_name
+        config['work_dir_exp'] = os.path.join(arg.work_dir, arg.exp_name)
+    
     return config
 
 
@@ -93,33 +82,44 @@ def get_metrics(output, mask):
     return f1_score, recall, precision
 
 
-def pixel_accuracy(output, mask):
+def label_accuracy_score(hist):
+    """
+    Returns accuracy score evaluation result.
+      - [acc]: overall accuracy
+      - [acc_cls]: mean accuracy
+      - [mean_iu]: mean IU
+      - [fwavacc]: fwavacc
+    """
+    acc = np.diag(hist).sum() / hist.sum()
+    with np.errstate(divide='ignore', invalid='ignore'):
+        acc_cls = np.diag(hist) / hist.sum(axis=1)
+    acc_cls = np.nanmean(acc_cls)
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        iu = np.diag(hist) / (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
+    mean_iu = np.nanmean(iu)
+
+    freq = hist.sum(axis=1) / hist.sum()
+    fwavacc = (freq[freq > 0] * iu[freq > 0]).sum()
+    return acc, acc_cls, mean_iu, fwavacc, iu
+
+
+def add_hist(hist, label_trues, label_preds, n_class):
+    """
+        stack hist(confusion matrix)
+    """
     with torch.no_grad():
-        output = torch.argmax(F.softmax(output, dim=1), dim=1)
-        correct = torch.eq(output, mask).int()
-        accuracy = float(correct.sum()) / float(correct.numel())
-    return accuracy
+        label_preds = torch.argmax(label_preds, dim=1).detach().cpu().numpy()
+        label_trues = label_trues.detach().cpu().numpy()
+    for lt, lp in zip(label_trues, label_preds):
+        hist += _fast_hist(lt.flatten(), lp.flatten(), n_class)
+
+    return hist
 
 
-def mIoU(pred_mask, mask, classwise=False, smooth=1e-10, n_classes=11):
-    with torch.no_grad():
-        pred_mask = F.softmax(pred_mask, dim=1)
-        pred_mask = torch.argmax(pred_mask, dim=1)
-        pred_mask = pred_mask.contiguous().view(-1)
-        mask = mask.contiguous().view(-1)
-
-        iou_per_class = []
-        for clas in range(0, n_classes):  # loop per pixel class
-            true_class = pred_mask == clas
-            true_label = mask == clas
-            intersect = torch.logical_and(true_class, true_label).sum().item()
-            union = torch.logical_or(true_class, true_label).sum().item()
-            
-            iou = (intersect+smooth) / (union+smooth)
-            iou_per_class.append(iou)
-        
-        if classwise == False:
-            return mean(iou_per_class)
-        else:
-            return iou_per_class
-
+def _fast_hist(label_true, label_pred, n_class):
+    mask = (label_true >= 0) & (label_true < n_class)
+    hist = np.bincount(
+        n_class * label_true[mask].astype(int) +
+        label_pred[mask], minlength=n_class ** 2).reshape(n_class, n_class)
+    return hist


### PR DESCRIPTION
## What is this PR?
torch baseline에 inference.py를 추가하고 전체적으로 refactoring 진행하였습니다.

## Changes
1. dataset.py : `CustomDataLoader` return 변경, `inference.py`에서 사용하기 위한 collate_fn 추가
2. inference.py : 새로 추가
3. smp_model.py
4. train.py : refactoring
5. utils.py : refactoring, 기존의 mIoU, pixel_accuracy를 baseline 평가 함수로 변경

## To reviewers
1. train(inference).py의 `args`는 실험 관련 setting들을,
torch 폴더에 있는 `config.yaml`은 모델 관련 config들이 저장되어 있는 상태고,
`load_config`, `concat_config`를 통해 이 둘을 합쳐서 사용하는 방식입니다.
2. `inference.py` 사용 시 args 중 exp-name, model-name만 바꾸시면 됩니다!
3. 전체적인 파일 구조는 하기 이미지와 같습니다.
빨간 네모 친 `../submission/sample_submission.csv` `./config.yaml` 있어야 합니다!
4. **[중요]** 처음 돌리시는 분은
#5 에서 라이브러리 설치해주시고,
#6 에서 wandb_setup.py 참고해서 직접 만들어주셔야 합니다!

![image](https://user-images.githubusercontent.com/81875412/165659873-17446e1e-433e-4bc9-90b6-5bd1942bf582.png)
