### PR TITLE
[fix] inference time visualize with fiftyone

### DIFF
--- a/sub_to_json.py
+++ b/sub_to_json.py
@@ -1,57 +1,79 @@
-import json
 import cv2
+import json
 import argparse
-import pandas as pd
 import numpy as np
+import pandas as pd
 from PIL import Image
 from tqdm import tqdm
-import time
 import pycocotools._mask as _mask
 
+class_labels = {
+    # 0: "Background",
+    1: "General trash",
+    2: "Paper",
+    3: "Paper pack",
+    4: "Metal",
+    5: "Glass",
+    6: "Plastic",
+    7: "Styrofoam",
+    8: "Plastic bag",
+    9: "Battery",
+    10: "Clothing",
+}
+
+
+def sqz(arr): # 차원 squeeze
+    return np.squeeze(np.array(arr).reshape(1, -1), axis=0).tolist()
+
+
 def main(arg):
-    sub_df = pd.read_csv(arg.sub_csv) # 제출한 csv
+    sub_df = pd.read_csv(arg.sub_csv) # 제출용 csv
     
-    # test.json
-    with open("../data/test.json", "r") as js:
+    with open("/opt/ml/input/data/test.json", "r") as js:
         test_js = json.load(js)
     test_js['annotations'] = [] # 초기화
     
-    def sqz(arr): # 차원 squeeze
-        return np.squeeze(arr.reshape(1, -1), axis=0).tolist()
     print('Start conversion.')
-    n_id = 0
-    for i in tqdm(range(len(sub_df))):
-        mat = np.array(sub_df['PredictionString'][i].split(), dtype=np.uint16).reshape(256, 256) # 1x65536 to 256x256
-        img = Image.fromarray(np.uint16(mat)*25) # array to segmentation image
+    annot_id = 0
+    for image_id in tqdm(range(len(sub_df))):
+        mat = np.array(sub_df['PredictionString'][image_id].split(), dtype=np.uint16).reshape(256, 256) # 1x65536 to 256x256
+        img = Image.fromarray(np.uint16(mat)) # array to segmentation image
         img = img.resize((512, 512)) # resize 512x512
         img = np.array(img, dtype=np.uint8) # segmentation image to array
-        ret, binary = cv2.threshold(img, 1, 255, cv2.THRESH_BINARY) # 배경(0), 물체(1~10)
-        contours, hierarchy = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE) # 외곽선
-        seg = list(map(sqz, contours)) # 차원, list
-        R = _mask.frPoly(seg, 512, 512)
-        area = _mask.area(R) # area
-        bbox = _mask.toBbox(R) # bbox
-        for j in range(len(seg)):
-            test_js['annotations'].append({
-                "id": n_id,
-                "image_id": i,
-                "category_id": int(mat[seg[j][1]//2][seg[j][0]//2]),
-                "segmentation": [seg[j]],
-                "area": int(area[j]),
-                "bbox": bbox[j].tolist(),
-                "iscrowd": 0
-            })
-            n_id += 1
+        
+        for category_id, category_name in class_labels.items():
+            new_img = np.where(img!=category_id, 0, img) # 특정 class에 속하지 않으면 모두 0
+            ret, binary = cv2.threshold(new_img, 0.5, 255, cv2.THRESH_BINARY) # 배경(0), 특정 claas(1)
+            contours, hierarchy = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE) # 외곽선
+            seg = list(map(sqz, contours)) # 차원, list
+            R = _mask.frPoly(seg, 512, 512)
+            area = _mask.area(R) # area
+            bbox = _mask.toBbox(R) # bbox
+
+            for seg_id in range(len(seg)):
+                test_js['annotations'].append({
+                    "id": annot_id,
+                    "image_id": image_id,
+                    "category_id": category_id,
+                    "segmentation": [seg[seg_id]],
+                    "area": int(area[seg_id]),
+                    "bbox": bbox[seg_id].tolist(),
+                    "iscrowd": 0
+                })
+                annot_id += 1
     print('End conversion.')
+    
     print('saving a json file...')
     with open(arg.dst_json, "w") as json_file:
         json.dump(test_js, json_file, indent=4)
-        
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--sub_csv', '-s', type=str, default='/opt/ml/input/code/submission/fcn_resnet50_best_model(pretrained).csv',
+    parser.add_argument('--sub_csv', '-s', type=str,
+                        default='/opt/ml/input/level2-semantic-segmentation-level2-cv-17/torch/work_dirs/exp_19/best_miou_epoch55.csv',
                         help='submission csv path')
-    parser.add_argument('--dst_json', '-d', type=str, default='/opt/ml/input/code/submission/inference.json',
+    parser.add_argument('--dst_json', '-d', type=str,
+                        default='/opt/ml/input/level2-semantic-segmentation-level2-cv-17/torch/work_dirs/exp_19/best_miou_epoch55.json',
                         help='inference json path')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## What is this PR?
이슈 #4 : class별 mask 시각화가 잘 되지 않던 현상을 수정하기 위한 PR입니다.

## Changes
- 가끔 문제가 되길래, test.json 경로를 절대경로로 바꾸었습니다.
- 각 class 별로 for문을 돌게 하고, 이 과정에서 np.where로 해당 class 값만 남긴 후에, 기존의 thres, contours, seg 등등의 계산이 이루어지도록 하였습니다. 

## To reviewers
- class가 다르면서 경계가 접하는 경우, 정상적으로 구분되는 것 같습니다.
- 다만 동일한 class이면서 경계가 접하는 경우, 여전히 하나의 객체로 인식하고 있습니다.
- mask별 color 설정도 해보려고 했는데, 적용이 되지 않고 필요한 기능은 아니라고 생각해서 포기했습니다.
![image](https://user-images.githubusercontent.com/81875412/166152028-221d5122-cc31-4142-87ce-951c3c51aa0c.png)